### PR TITLE
docs: deprecate in favour of kaiseki/scaffold-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # kaiseki/scaffold-wp-module
 
+> **Deprecated — archived.** This scaffold has been consolidated into
+> [`kaiseki/scaffold-module`](https://github.com/kaisekidev/kaiseki-scaffold-module),
+> which generates **both** WordPress and Core modules on the current org
+> baseline (PHP 8.4, PHPStan 2, PHPUnit 11, shared CI). Use that instead:
+>
+> ```bash
+> composer create-project --no-dev kaiseki/scaffold-module <directory>
+> ```
+
 Scaffold a WordPress module
 
 ## Usage


### PR DESCRIPTION
Consolidation step of the PHP 8.4 migration (Phase 5). This scaffold is a near-duplicate of [`kaiseki/scaffold-module`](https://github.com/kaisekidev/kaiseki-scaffold-module), which now generates **both** WordPress and Core modules on the current baseline and has shipped `1.0.0`.

Adds a deprecation banner pointing users to the canonical scaffold. The repo will be archived after this merges.